### PR TITLE
PKG: Add MANIFEST.in, update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ Makefile
 /build
 /dist
 /bayesfit.egg-info
+/.vscode

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include README.rst
+include LICENSE.txt


### PR DESCRIPTION
This PR adds a `MANIFEST.in` file which will ensure that the license and readme file are included in the source distribution (created via `python setup.py sdist`)